### PR TITLE
Fix update exit call

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -1116,7 +1116,7 @@ def on_message(client, userdata, msg):
                 thread1.join()  # Wait for thread1 to finish
             if thread2 is not None:
                 thread2.join()  # Wait for thread2 to finish
-            os._exit(0)  # Exit the script immediately
+            sys.exit(0)  # Exit the script allowing cleanup handlers
 
         update_thread = threading.Thread(target=update_and_exit)
         update_thread.start()


### PR DESCRIPTION
## Summary
- exit using `sys.exit()` to allow clean-up handlers to run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593619d2ec832d983ef6e6c1bfca8a