### PR TITLE
Fix tests without requests

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -23,6 +23,7 @@ sys.modules['paho'] = paho_module
 sys.modules['paho.mqtt'] = paho_mqtt_module
 sys.modules['paho.mqtt.client'] = paho_client_module
 sys.modules['psutil'] = types.ModuleType("psutil")
+sys.modules['requests'] = types.ModuleType("requests")
 
 spec = importlib.util.spec_from_file_location("monitor", str(SRC_DIR / "rpi-cpu2mqtt.py"))
 monitor = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- stub out requests to let rpi-cpu2mqtt load when `requests` is missing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593d92ecb4832d9ec9426df5ba4abc