### PR TITLE
Improve reliability and tests

### DIFF
--- a/ext_sensor_lib/ds18b20.py
+++ b/ext_sensor_lib/ds18b20.py
@@ -14,9 +14,8 @@ def sensor_DS18B20(sensor_id, verbose=False):
     """
     # read the file
     try:
-        file = open('/sys/bus/w1/devices/28-%s/w1_slave' % sensor_id)
-        filecontent = file.read()
-        file.close()
+        with open('/sys/bus/w1/devices/28-%s/w1_slave' % sensor_id) as file:
+            filecontent = file.read()
         # read temperature value and convert it
         stringvalue = filecontent.split("\n")[1].split(" ")[9]
         temperature = float(stringvalue[2:]) / 1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 paho-mqtt==1.6.1
-requests
-psutil
+requests==2.32.4
+psutil==7.0.0

--- a/tests/test_ds18b20.py
+++ b/tests/test_ds18b20.py
@@ -1,0 +1,24 @@
+import builtins
+from unittest import mock
+
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).parents[1]
+# Insert module path for ext_sensor_lib
+sys.path.insert(0, str(SRC_DIR))
+
+# import module
+import ext_sensor_lib.ds18b20 as ds18b20
+
+
+def test_sensor_ds18b20_reads_file():
+    fake_data = "x\n" + " ".join(["0"] * 9 + ["t=23000"])
+    with mock.patch.object(builtins, "open", mock.mock_open(read_data=fake_data)):
+        assert ds18b20.sensor_DS18B20("0000") == 23.0
+
+
+def test_get_available_sensors_filters_ids():
+    with mock.patch.object(ds18b20.os, "listdir", return_value=["28-abc", "foo", "28-123"]):
+        sensors = ds18b20.get_available_sensors()
+    assert sensors == ["abc", "123"]


### PR DESCRIPTION
## Summary
- pin `requests` and `psutil` versions
- use a context manager when reading DS18B20 sensors
- add tests for DS18B20 helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594087d3d8832d83b0c32b3cf46a7b