### PR TITLE
Use context manager for DS18B20 sensor file

### DIFF
--- a/ext_sensor_lib/ds18b20.py
+++ b/ext_sensor_lib/ds18b20.py
@@ -13,9 +13,8 @@ def sensor_DS18B20(sensor_id, verbose=False):
     """
     # read the file
     try:
-        file = open('/sys/bus/w1/devices/28-%s/w1_slave' % sensor_id)
-        filecontent = file.read()
-        file.close()
+        with open('/sys/bus/w1/devices/28-%s/w1_slave' % sensor_id, 'r') as sensor_file:
+            filecontent = sensor_file.read()
         # read temperature value and convert it
         stringvalue = filecontent.split("\n")[1].split(" ")[9]
         temperature = float(stringvalue[2:]) / 1000

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -15,6 +15,7 @@ SRC_DIR = Path(__file__).parents[1] / "src"
 sys.path.insert(0, str(SRC_DIR))
 
 import update
+import ext_sensor_lib.ds18b20 as ds18b20
 
 # Insert mocks for optional third party libraries so tests run without them
 paho_module = types.ModuleType("paho")
@@ -72,6 +73,18 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(monitor.sanitize_numeric(10), 10)
         self.assertEqual(monitor.sanitize_numeric(None), 0)
         self.assertEqual(monitor.sanitize_numeric(float('nan')), 0)
+
+    def test_sensor_ds18b20_success(self):
+        sensor_output = (
+            '76 01 4b 46 7f ff 0c 10 e6 : crc=e6 YES\n'
+            '76 01 4b 46 7f ff 0c 10 e6 t=23125\n'
+        )
+        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=sensor_output)):
+            self.assertEqual(ds18b20.sensor_DS18B20('0000'), 23.1)
+
+    def test_sensor_ds18b20_missing_file(self):
+        with mock.patch.object(builtins, 'open', side_effect=IOError):
+            self.assertEqual(ds18b20.sensor_DS18B20('0000'), -300.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- refactor DS18B20 file handling to use `with` statement
- test DS18B20 reading in normal and error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0e379f08832d85b27038393b4bd9